### PR TITLE
#134 - remove login barrier

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -47,8 +47,6 @@ $(document).ready(function()
 
 	$(".new-issue-line").change(function()
 	{
-		var self = this;
-
 		$.ajax({
 		  url: "/lines/" + $(this).val() + "/get_stops",
 		  context: document.body
@@ -61,4 +59,8 @@ $(document).ready(function()
 			});
 		});
 	});
+
+	$("#opt-out-login").click(function() {
+	  document.cookie = "opted_out_of_login=true;path=/"
+  })
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,7 +41,7 @@ body {
 .page-container {
 	max-width: $max-width-page;
 	margin: auto;
-	padding: 0px $page-padding;
+	padding: $page-padding;
 
 	&.-thin { max-width: 600px; }
 }

--- a/app/assets/stylesheets/variables.scss.erb
+++ b/app/assets/stylesheets/variables.scss.erb
@@ -4,7 +4,7 @@ $theme-color: <%= Setting.theme_color %>;
 /** Other Variables **/
 $header-height: 50px;
 $max-width-page: 1200px;
-$page-padding: 15px;
+$page-padding: 1rem;
 
 /** Colors **/
 $background-grey: #EFEFF4;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  include SessionsHelper
+
+  # override devise's method of the same name
+  # take user back to last page if available
+  def after_sign_in_path_for(resource_or_scope)
+    inferred_last_page_path.blank? ?
+      super : inferred_last_page_path(allowed_query_params: :line_type)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,6 @@ class ApplicationController < ActionController::Base
   # take user back to last page if available
   def after_sign_in_path_for(resource_or_scope)
     inferred_last_page_path.blank? ?
-      super : inferred_last_page_path(allowed_query_params: :line_type)
+      super : inferred_last_page_path(allowed_query_params: [:line_type])
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -16,8 +16,11 @@ class IssuesController < ApplicationController
 
   # GET /issues/new
   def new
-    unless user_signed_in?
-      redirect_to new_user_session_path
+    unless user_signed_in? || cookies[:opted_out_of_login]
+      redirect_to new_user_session_path(params: {
+        from: new_issue_path,
+        line_type: params[:line_type]
+      })
     end
 
     @line_type = params[:line_type]

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -8,9 +8,13 @@ module SessionsHelper
       return nil
     end
 
-    query_params = options[:allowed_query_params] ?
-                     params.slice(*options[:allowed_query_params]).to_query : ""
+    query_params = {}
+    if options[:allowed_query_params]
+      options[:allowed_query_params].each do |query_param|
+        query_params[query_param] = params[query_param]
+      end
+    end
 
-    params[:from] + "?" + query_params
+    params[:from] + "?" + query_params.to_query
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SessionsHelper
+  # returns the path from which a user came. A query parameters called "from" must be present for
+  # this method to work properly. We'll pass the other query params as query params to the next page.
+  def inferred_last_page_path(options = {})
+    if params[:from].blank?
+      return nil
+    end
+
+    query_params = options[:allowed_query_params] ?
+                     params.slice(*options[:allowed_query_params]).to_query : ""
+
+    params[:from] + "?" + query_params
+  end
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -18,7 +18,7 @@
 
 
 class Issue < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, required: false
   belongs_to :stop, foreign_key: "stop_onestop_id"
   belongs_to :vehicle, required: false
   belongs_to :line, foreign_key: "line_onestop_id"

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,6 +15,11 @@
     <div class="actions">
       <%= f.submit "Log in", :class => 'pill' %>
     </div>
+
+    <%# Pass query params to sign in controller - this way we can redirect back to where they came from %>
+    <% params.keys.each do |param_name| %>
+      <%= hidden_field_tag param_name, params[param_name] %>
+    <% end %>
   <% end %>
 
   <%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,27 +2,31 @@
   
   <div id="signin-options">
 
+    <%- unless params[:from].blank? %>
+      <%=  link_to "Opt out", inferred_last_page_path(allowed_query_params: [:line_type]), id: "opt-out-login"  %>
+    <% end -%>
+
     <%- if controller_name != 'sessions' %>
-      <div id="signin-options" class = ''>  <%= link_to "Log in", new_session_path(resource_name), class: "login-link" %><br /></div>
+      <div id="signin-options" class = ''>  <%= link_to "Log in", new_session_path(resource_name), class: "login-link" %></div>
     <% end -%>
 
     <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-      Don't have an account? <%= link_to "Sign up", new_registration_path(resource_name), class: "login-link" %><br />
-      Forgot password? <%= link_to "Reset password", new_password_path(resource_name), class: "login-link" %><br />
+      <%= link_to "Sign up", new_registration_path(resource_name), class: "login-link" %>
+      <%= link_to "Reset password", new_password_path(resource_name), class: "login-link" %>
     <% end -%>
 
 
     <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-      <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+      <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %>
     <% end -%>
 
     <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-      <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+      <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
     <% end -%>
 
     <%- if devise_mapping.omniauthable? %>
       <%- resource_class.omniauth_providers.each do |provider| %>
-        <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+        <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %>
       <% end -%>
     <% end -%>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount RailsSettingsUi::Engine, at: 'settings'
-  devise_for :users
+  devise_for :users, controllers: { sessions: "devise/sessions"}
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   # General page routes. Will include items like home and top-level pages

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -99,10 +99,10 @@ end
 puts 'Destroying old users and seeding fake ones'
 
 User.destroy_all
-AMOUNT_USERS.times do |i|
+AMOUNT_USERS.times do
   User.create!(
       email: Faker::Internet.email,
-      password: "cat-dog-#{i}",
+      password: "cat-dog",
       # reset_password_token: ?,
       # reset_password_sent_at: ?,
       remember_created_at: Faker::Time.between(20.days.ago, Date.today, :all),


### PR DESCRIPTION

### Description of Changes:

1. I added an "opt out link" on the login page that only shows up when the "from" query parameters.
2. Added JS code to add a "opted out of login" cookie to the user's browser. This cookie is sent to the back-end with every request. Opt out button also goes to the previous page. See the `inferred_last_page_path` method.
3. Added the query parameters to the login for as hidden params. This way, when the user logs in, they will also go to the page that they were trying to access. This is a little bonus. Devise, the library we use for login, allows us to override some methods on our `ApplicationController` (from which all other controllers inherit). [More info here](https://www.rubydoc.info/github/plataformatec/devise/Devise%2FControllers%2FHelpers:after_sign_in_path_for)



### How This Was Tested:
Didn't write new tests. Manually went through this. Might try to write some UI tests later.
All existing tests pass.


### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing

