### PR TITLE
Closes #154 - fix association between lines and issues

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -11,6 +11,6 @@ class LinesController < ApplicationController
 
   def get_stops
     @line = Line.find(params[:line_id])
-    render json: @line.stops.pluck(:id, :name)
+    render json: @line.stops.pluck(:onestop_id, :name)
   end
 end

--- a/test/controllers/issues_controller_test.rb
+++ b/test/controllers/issues_controller_test.rb
@@ -52,7 +52,7 @@ class IssuesControllerTest < ActionDispatch::IntegrationTest
 
   test "creating issue fails if it does not have type" do
     post issues_url params: { issue: {
-        stop_onestop_id: stops(:one).id,
+        stop_onestop_id: stops(:one).onestop_id,
         line_onestop_id: lines(:one).id,
         description: "something"
     } }

--- a/test/fixtures/stops.yml
+++ b/test/fixtures/stops.yml
@@ -1,5 +1,5 @@
 one:
   id: 1
   name: "stop1"
-  onestop_id: "test-stop~id"
+  onestop_id: "test-stop-id"
 


### PR DESCRIPTION
### Description of Changes:
Used  the developer tools in the browser to notice that the values in the stop dropdown don't match those in the database. Looks like plucking the `:id` was bringing out the wrong number. Not sure why. Looks like the `:onestop_id` has the same value and works.


### How This Was Tested:
Ran through this in the browser.

### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing

### Questions / Additional Notes:
