### PR TITLE
switch to black search icon

### DIFF
--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -49,7 +49,7 @@
 }
 
 .search {
-	background-image: url(asset-path('search-white.svg'));
+	background-image: url(asset-path('search.svg'));
 	height: $header-height;
 	width: $header-height;
 	background-size: 80%;


### PR DESCRIPTION
Per Tomer's request, this switches the search icon from the white-colored one to the black-colored one.

