### PR TITLE
Read ruby version from .ruby-version in Gemfile to reduce duplication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
-ruby '2.4.4'
 
+if File.exist?('.ruby-version')
+  ruby "#{File.read('.ruby-version')}"
+end
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 if File.exist?('.ruby-version')
-  ruby "#{File.read('.ruby-version')}"
+  ruby "#{File.read('.ruby-version').strip()}"
 end
 
 git_source(:github) do |repo_name|


### PR DESCRIPTION
### Description of Changes:
In the Gemfile there is a line to define the version of ruby that is being used. That information is also defined in the .ruby-version file in the root of the application directory. This change 

### How This Was Tested:
Manual testing of doing bundle install, then renaming .ruby-version to .ruby-version.old, rerunning bundle install, then renaming .ruby-version back to its original name and running bundle install one last to time to make sure it works
