### PR TITLE
Add switch for dev/prod stop list generation

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,9 +2,13 @@
 
 class PagesController < ApplicationController
   def view_issues
-    # If our location.js has pulled a location, use it to find Stops
-    if (params[:lat]) && (params[:long])
-      @nearby_stops = Stop.includes(:lines).within(0.2, origin: [params[:lat], params[:long]])
+	# If rails is not prod, just take the top 50 stops.
+	# There is a known issue with SQLite and the geolocation gem
+	if (Rails.env != "production")
+		@nearby_stops = Stop.take(50)
+	# If our location.js has pulled a location, use it to find Stops
+	elsif (params[:lat]) && (params[:long])
+		@nearby_stops = Stop.includes(:lines).within(0.2, origin: [params[:lat], params[:long]])
     end
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,13 +2,13 @@
 
 class PagesController < ApplicationController
   def view_issues
-	# If rails is not prod, just take the top 50 stops.
-	# There is a known issue with SQLite and the geolocation gem
-	if (Rails.env != "production")
-		@nearby_stops = Stop.take(50)
-	# If our location.js has pulled a location, use it to find Stops
-	elsif (params[:lat]) && (params[:long])
-		@nearby_stops = Stop.includes(:lines).within(0.2, origin: [params[:lat], params[:long]])
+    # If rails is not prod, just take the top 50 stops.
+    # There is a known issue with SQLite and the geolocation gem
+    if !Rails.env.production?
+      @nearby_stops = Stop.take(50)
+    # If our location.js has pulled a location, use it to find Stops
+    elsif (params[:lat]) && (params[:long])
+      @nearby_stops = Stop.includes(:lines).within(0.2, origin: [params[:lat], params[:long]])
     end
   end
 


### PR DESCRIPTION
Closes #166 - View Issues throws SQLException

### Description of Changes:
Add check on environment flag. If it is prod, we do the existing geolocation. If it is not, we simply grab the top 50 stops so we don't lose functionality.


### How This Was Tested:
Manual testing, rails test.


### Related Issue(s) or Specifications:
Closes #166 

### Checklist:
- [x] Code follows code style of this project
- [ ] Tests added to cover changes
- [x] All new and existing tests passing

### Questions / Additional Notes:
