### PR TITLE
Minimize DB calls 

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -6,7 +6,7 @@ class LinesController < ApplicationController
   end
 
   def show
-    @line = Line.find(params[:id])
+    @line = Line.includes(stops: [:issues]).find(params[:id])
   end
 
   def get_stops

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,10 +5,10 @@ class PagesController < ApplicationController
     # If rails is not prod, just take the top 50 stops.
     # There is a known issue with SQLite and the geolocation gem
     if !Rails.env.production?
-      @nearby_stops = Stop.with_issue_count.take(50)
+      @nearby_stops = Stop.includes(:lines, :issues).take(50)
     # If our location.js has pulled a location, use it to find Stops
     elsif (params[:lat]) && (params[:long])
-      @nearby_stops = Stop.includes(:lines).within(0.2, origin: [params[:lat], params[:long]])
+      @nearby_stops = Stop.includes(:lines, :issues).within(0.2, origin: [params[:lat], params[:long]])
     end
   end
 
@@ -21,7 +21,7 @@ class PagesController < ApplicationController
   end
 
   def search
-    @result_lines = Line.where(
+    @result_lines = Line.includes(:stops).where(
       "name LIKE ? OR route_long_name LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%"
     )
     @result_stops = Stop.includes(:lines).where(

--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -2,6 +2,6 @@
 
 class StopsController < ApplicationController
   def show
-    @stop = Stop.find(params[:stop_id])
+    @stop = Stop.includes(:issues).find(params[:stop_id])
   end
 end

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -47,9 +47,4 @@ class Stop < ApplicationRecord
   def html_safe_id
     id.gsub(/~/, "-")
   end
-
-  # adds num_issues attribute
-  def self.with_issue_count
-    Stop.left_joins(:issues).select("stops.*, count(issues.id) as num_issues").group("stops.onestop_id")
-  end
 end

--- a/app/views/stops/_show.html.erb
+++ b/app/views/stops/_show.html.erb
@@ -1,3 +1,4 @@
+<% current_line ||= nil %>
 <div class="stop-partial">
   <span>
 		<%= link_to stop.name, stop %>
@@ -8,13 +9,9 @@
 				<%= render "favorites/unfavorite", stop: stop %>
 			<% end %>
     <% end %>
-    <%= new_issue_button(stop: stop) %>
+    <%= new_issue_button(stop: stop, line: current_line) %>
   </span>
   <span>
-      <% if stop.respond_to?(:num_issues) %>
-			  <%= stop.num_issues %>
-      <% else %>
-        <%= stop.issues.count %>
-      <% end %>
+    <%= stop.issues.length %>
   </span>
 </div>


### PR DESCRIPTION
Long story short - this makes less calls to the DB. Read section 13 in [this link](https://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations) to find out why.

Also, `count` makes a DB call but `length` doesn't. Go figure!

### Related Issue(s) or Specifications:
- I'm going to create a new PR for not loading the "settings" so often(every page load makes a call to the DB to get the name of the site, which doesn't change very often). However, we'll need to update the version of Ruby that we're using to the latest gems.

### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing
