### PR TITLE
Add limit of 25 to each result type

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,10 +26,10 @@ class PagesController < ApplicationController
   def search
     @result_lines = Line.includes(:stops).where(
       "name LIKE ? OR route_long_name LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%"
-    )
+    ).take(25)
     @result_stops = Stop.includes(:lines).where(
       "stops.name LIKE ?", "%#{params[:q]}%").order("lines.vehicle_type DESC"
-    )
+    ).take(25)
   end
 
   def valid_page?


### PR DESCRIPTION
Limits search results to 25 of each type. Without this guard, the user can search for an empty string which will match every record in the DB and crash the app.

### Checklist:
- [x] Code follows code style of this project
- [ ] Tests added to cover changes
- [x] All new and existing tests passing

