### PR TITLE
Style touchups

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,13 +19,13 @@ $(document).on('ready turbolinks:load', function()
 {
 	$("header .hamburger").click(function()
 	{
-		$(".side-menu").animate({"left": '0%'});
+		$(".side-menu").animate({"right": '0%'});
 		$(".side-menu-overlay").fadeIn();
 	});
 
 	$(".side-menu-overlay").click(function()
 	{
-		$(".side-menu").animate({"left": '-85%'});
+		$(".side-menu").animate({"right": '-85%'});
 		$(".side-menu-overlay").fadeOut();
 	});
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -137,3 +137,41 @@ button.no-style {
 	background: blue;
 	color: white;
 }
+
+.separator {
+	height: 10px;
+	width: 90%;
+	margin: 2rem auto;
+	display: flex;
+	justify-content: space-between;
+	position: relative;
+	vertical-align: middle;
+
+	.node-external {
+		top: -50%;
+		width: 1.25rem;
+		height: 1.25rem;
+		background-color: #000000;
+		border-radius: 50%;
+		position: relative;
+
+		&.left {
+			left: -5px;
+		}
+		
+		&.right {
+			right: -5px;
+		}
+
+		.node-internal {
+			top: 25%;
+			left: 25%;
+			width: 50%;
+			height: 50%;
+			background-color: #ffffff;
+			border-radius: 50%;
+			position: relative;
+		}
+
+	}
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -151,14 +151,14 @@ button.no-style {
 		top: -50%;
 		width: 1.25rem;
 		height: 1.25rem;
-		background-color: #000000;
+		background-color: #000;
 		border-radius: 50%;
 		position: relative;
 
 		&.left {
 			left: -5px;
 		}
-		
+
 		&.right {
 			right: -5px;
 		}
@@ -168,10 +168,9 @@ button.no-style {
 			left: 25%;
 			width: 50%;
 			height: 50%;
-			background-color: #ffffff;
+			background-color: #fff;
 			border-radius: 50%;
 			position: relative;
 		}
-
 	}
 }

--- a/app/assets/stylesheets/headers.scss
+++ b/app/assets/stylesheets/headers.scss
@@ -82,7 +82,7 @@
 	border: 2px solid #414141;
 	top: 0;
 	border-radius: 10px;
-	left: -85%;
+	right: -85%;
 	box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
 	z-index: 10;
 }

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,12 +1,5 @@
 @import 'variables';
 
-@mixin separator($color) {
-	background: image_url("separator-#{$color}.svg") no-repeat center;
-	height: 25px;
-	width: 400px;
-	margin: 2rem auto;
-}
-
 .issues-label {
 	padding-top: 15px;
 	padding-bottom: 5px;
@@ -18,14 +11,6 @@
 	padding: 1rem;
 	max-width: 960px;
 	margin: 0 auto;
-
-	.green-separator {
-		@include separator('green');
-	}
-
-	.red-separator {
-		@include separator('red');
-	}
 
 	h2 {
 		font-size: 1.75rem;

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="green-separator separator"></div>
+  <%= render "shared/separator", color: "blue" %>
 
   <% if @favorites.present? %>
     <h3 class="heading">Favorite Stops</h3>
@@ -39,16 +39,15 @@
       <%= render "shared/striped_table", table_collection: @favorites, row_partial: "stops/show_with_issues", row_options: @stop_view_options %>
     </div>
 
-    <div class="green-separator separator"></div>
+    <%= render "shared/separator", color: "green" %>
   <% end %>
 
   <div data-controller="nearby-stops">
-    <h3 class="heading">Nearby Issues</h3>
+    <h3 class="heading">Nearby Stops</h3>
 
   <div data-target="nearby-stops.content">Loading...</div>
 
-
-  <div class="red-separator separator"></div>
+  <%= render "shared/separator", color: "red" %>
 
   <%= link_to('Select Routes', lines_path, class: 'brown-btn') %>
 </div>

--- a/app/views/shared/_separator.html.erb
+++ b/app/views/shared/_separator.html.erb
@@ -1,0 +1,6 @@
+<% color = 'green' if local_assigns[:color].nil? %>
+
+<div class="separator" style="background-color: <%=color%>">
+    <div class="node-external left"><div class="node-internal"></div></div>
+    <div class="node-external right"><div class="node-internal"></div></div>
+</div>

--- a/app/views/stops/_show.html.erb
+++ b/app/views/stops/_show.html.erb
@@ -31,9 +31,9 @@
       <% if options.fetch(:show_line_colors, true) && transfers.any? %>
         <div class="transfers row">
           <% if main_line.nil? %>
-            Serviced by:
+            <div style="text-align:left">Serviced by:</div>
           <% else %>
-            Transfers:
+            <div>Transfers:</div>
           <% end %>
           <div class="stop-identifiers row">
             <% transfers.each do |line| %>


### PR DESCRIPTION
Fixing up a few issues we noticed during the demo and over time.

- Converted separators to a purely html/css solution. It now scales much better with different screen sizes.
- Hamburger menu now properly expands from the right side
- "Serviced By" text now gets left-aligned in the div, fixing weird-looking text when enough transfer circles exist to make it go into two lines