### PR TITLE
Accessibility labels

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -44,7 +44,11 @@ textarea {
 }
 
 .checkbox-container input {
-	display: none;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	margin: 0;
+	display: inline; 
 }
 
 .checkbox-tile {

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -6,7 +6,7 @@ module IssuesHelper
     link_to("Report\nIssue",
       new_issue_path(line_id: line&.id, stop_id: stop&.id),
       id: "create-issue-#{stop&.id}", class: "create-issue",
-      aria: { label: "Report issue at " + stop.name }
+      aria: { label: unless stop.nil? then "Report issue at " + stop.name else "Report issue" end }
     )
   end
 end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -5,7 +5,8 @@ module IssuesHelper
     line ||= stop&.lines&.first
     link_to("Report\nIssue",
       new_issue_path(line_id: line&.id, stop_id: stop&.id),
-      id: "create-issue-#{stop&.id}", class: "create-issue"
+      id: "create-issue-#{stop&.id}", class: "create-issue",
+      aria: { label: "Report issue at " + stop.name }
     )
   end
 end

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -25,9 +25,9 @@
         <label class="checkbox-container">
           <%= f.check_box(:types, { multiple: true }, issue_type, nil) %>
           <span class="checkbox-tile column centered">
-              <%= image_tag "issue_types/#{issue_type}.svg", alt: issue_type %>
+            <%= image_tag "issue_types/#{issue_type}.svg", alt: issue_type, aria: { hidden: true } %>
             <span class="checkbox-text"><%= issue_type %></span>
-        </span>
+          </span>
         </label>
       <% end %>
       <label class="checkbox-container wide">

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -23,9 +23,9 @@
     <div class="types-container">
       <% %w(Delays Cleanliness Crowding Safety Accessibility Staff).each do |issue_type| %>
         <label class="checkbox-container">
-          <%= f.check_box(:types, { multiple: true }, issue_type, nil) %>
+		  <%= f.check_box(:types, { multiple: true }, issue_type, nil) %>
           <span class="checkbox-tile column centered">
-            <%= image_tag "issue_types/#{issue_type}.svg", alt: issue_type, aria: { hidden: true } %>
+            <%= image_tag "issue_types/#{issue_type}.svg", alt: issue_type %>
             <span class="checkbox-text"><%= issue_type %></span>
           </span>
         </label>

--- a/app/views/issues/_split_button.html.erb
+++ b/app/views/issues/_split_button.html.erb
@@ -2,5 +2,5 @@
     <button data-target="split-button.button" data-action="click->split-button#select" data-to-show="trains_near"
             class="split-button selected" id="trains_near_button" aria-label="Get nearby trains">Trains</button>
     <button data-target="split-button.button" data-action="click->split-button#select" data-to-show="buses_near"
-            class="split-button" id="buses_near_button" aria-laebel="Get nearby buses">Buses</button>
+            class="split-button" id="buses_near_button" aria-label="Get nearby buses">Buses</button>
 </div>

--- a/app/views/issues/_split_button.html.erb
+++ b/app/views/issues/_split_button.html.erb
@@ -1,6 +1,6 @@
 <div id="type-select">
     <button data-target="split-button.button" data-action="click->split-button#select" data-to-show="trains_near"
-            class="split-button selected" id="trains_near_button">Trains</button>
+            class="split-button selected" id="trains_near_button" aria-label="Get nearby trains">Trains</button>
     <button data-target="split-button.button" data-action="click->split-button#select" data-to-show="buses_near"
-            class="split-button" id="buses_near_button">Buses</button>
+            class="split-button" id="buses_near_button" aria-laebel="Get nearby buses">Buses</button>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -11,17 +11,21 @@
   </h2>
 
   <div class="report-issues-cont">
-    <h3 class="heading">Report an Issue</h3>
+    <h3 class="heading" aria-hidden="true">Report an Issue</h3>
 
     <div class="transit-btn-cont">
-      <%= link_to(new_issue_path(line_type: 'bus'), class: 'blue-btn transit') do %>
+      <%= link_to(new_issue_path(line_type: 'bus'),
+        class: 'blue-btn transit',
+        aria: { label: "Report bus issue" } ) do %>
         <div style="color: white">Bus</div>
-        <%= image_tag "bus_white.svg", alt: '' %>
+        <%= image_tag "bus_white.svg", alt: '', aria: { hidden: true } %>
       <% end %>
 
-      <%= link_to(new_issue_path(line_type: 'train'), class: 'blue-btn transit') do %>
+      <%= link_to(new_issue_path(line_type: 'train'),
+        class: 'blue-btn transit',
+        aria: { label: "Report train issue" } ) do %>
         <div>Train</div>
-        <%= image_tag "train_white.svg", alt: '' %>
+        <%= image_tag "train_white.svg", alt: '', aria: { hidden: true } %>
       <% end %>
     </div>
   </div>
@@ -31,7 +35,7 @@
   <% if @favorites.present? %>
     <h3 class="heading">Favorite Stops</h3>
 
-    <div class="issues-label">
+    <div class="issues-label" aria-hidden="true">
       <span># of issues</span>
     </div>
 

--- a/app/views/stops/_show.html.erb
+++ b/app/views/stops/_show.html.erb
@@ -38,7 +38,7 @@
           <div class="stop-identifiers row">
             <% transfers.each do |line| %>
               <% if line.train? %>
-                <div class="line-swatch" style="background-color: <%= "##{line.color}" %>"></div>
+                <div aria-label="<%= line.name %>" class="line-swatch" style="background-color: <%= "##{line.color}" %>"></div>
               <% else %>
                 <div class="line-tile api-id"><%= line.name %></div>
               <% end %>
@@ -49,7 +49,7 @@
     </div>
   <% end %>
   <div class="issue-readout">
-    <div class="issue-count"><%= stop.issues.length %></div>
+    <div class="issue-count" aria-describedby="<%= stop.issues.length %> issues at <%= stop.name %>"><%= stop.issues.length %></div>
       <div class="issue-button">
           <%= new_issue_button(stop: stop, line: main_line) %>
       </div>


### PR DESCRIPTION
Covers a lot of our pages to remove confusing, misleading, or unimportant labels and add labels where the default text was not helpful.

Main problem has been the submit issue form which works but has room for improvement. First foray into accessibility labels so any fixes/best practices I missed please let me know!